### PR TITLE
Move Sanity credentials to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Sanity CMS Configuration
+# Get these values from your Sanity project dashboard at https://sanity.io/manage
+# These are server-side only and will not be exposed to the browser
+SANITY_PROJECT_ID=your_project_id
+SANITY_DATASET=production
+SANITY_API_VERSION=2025-01-11

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/sanity/sanity.client.ts
+++ b/sanity/sanity.client.ts
@@ -1,9 +1,9 @@
 import { createClient, type ClientConfig } from "@sanity/client";
 
 const config: ClientConfig = {
-  projectId: "whsvh8u8",
-  dataset: "production",
-  apiVersion: "2025-01-11",
+  projectId: process.env.SANITY_PROJECT_ID!,
+  dataset: process.env.SANITY_DATASET!,
+  apiVersion: process.env.SANITY_API_VERSION || "2025-01-11",
   useCdn: false,
 };
 


### PR DESCRIPTION
## Summary
Moves hardcoded Sanity credentials to server-side environment variables for improved security.

## Changes
- ✅ Created `.env.local` with Sanity credentials (server-side only)
- ✅ Created `.env.example` template for documentation
- ✅ Updated `sanity.client.ts` to use `process.env.SANITY_*`
- ✅ Updated `.gitignore` to allow `.env.example` while ignoring other env files
- ✅ Uses server-side env vars (NOT `NEXT_PUBLIC_*`) since only used in Server Components

## Security Improvements
- 🔒 Credentials never exposed to browser/client bundle
- 🔒 Smaller bundle size (no env vars in JavaScript)
- 🔒 Follows Next.js security best practices
- 🔒 Credentials kept out of source control

## Testing
- ✅ Build passes successfully
- ✅ `.env.local` detected and loaded
- ✅ All routes compile correctly
- ✅ Sanity queries work as expected

## Deployment Notes
When deploying to Vercel, add these environment variables:
```
SANITY_PROJECT_ID=whsvh8u8
SANITY_DATASET=production
SANITY_API_VERSION=2025-01-11
```

Closes #12